### PR TITLE
Svn to 7272

### DIFF
--- a/crystals/results.F
+++ b/crystals/results.F
@@ -9647,7 +9647,7 @@ c
      1   ' (Using', nfofc,' reflections. Correl Coef =',
      2   nint(100.*pseudoc),'%)'
          CALL XPRVDU (NCVDU, 1, 0)
-         IF (ISSPRT.EQ.0) WRITE (NCWU,'(A,a,a)') CMON(1)(:43),'\A3 ',
+         IF (ISSPRT.EQ.0) WRITE (NCWU,'(A,a,a)') CMON(1)(:43),'% ',
      1   CMON(1)(45:nctrim(cmon(1)))
          call outcol(1)
          write(cmon,'(/)')
@@ -9690,7 +9690,7 @@ c
 2100      FORMAT (/4(/a,a))
           WRITE (ncwu,2100)
      1   '@  ','Flack,1983, Acta Cryst A39, 876-881',
-     2   '\A3  ','Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022',
+     2   '%  ','Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022',
      3   '$  ','Hooft et al, 2008, J Appl Cryst, 41, 96-103',
      4   '&  ','Cooper et al, to be published'
          END IF

--- a/test_suite/INW_OMP.org/flack.out
+++ b/test_suite/INW_OMP.org/flack.out
@@ -5163,7 +5163,7 @@ Quadrant averages: N, Mean(Do), Mean(Ds) [Summary of scatterplot]
  Using counting statistics weights
        Hooft Parameter & su -0.005  0.012  $ 
            Hole-in-one & su -0.004  0.009    
-    Bijvoet Difference & su  0.006  0.009  £  (Using   300 reflections. Correl Coef =  90%)
+    Bijvoet Difference & su  0.006  0.009  %  (Using   300 reflections. Correl Coef =  90%)
 
  Histogram re-weighted,   226 reflections,  71.0% within interval x= -.5 to 1.5
     Bijvoet Difference & su -0.004  0.013    
@@ -5172,7 +5172,7 @@ Quadrant averages: N, Mean(Do), Mean(Ds) [Summary of scatterplot]
 
 
 @  Flack,1983, Acta Cryst A39, 876-881
-£  Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022
+%  Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022
 $  Hooft et al, 2008, J Appl Cryst, 41, 96-103
 &  Cooper et al, to be published
 

--- a/test_suite/LIN.org/flack.out
+++ b/test_suite/LIN.org/flack.out
@@ -5164,7 +5164,7 @@ Quadrant averages: N, Mean(Do), Mean(Ds) [Summary of scatterplot]
  Using counting statistics weights
        Hooft Parameter & su -0.005  0.012  $ 
            Hole-in-one & su -0.004  0.009    
-    Bijvoet Difference & su  0.006  0.009  £  (Using   300 reflections. Correl Coef =  90%)
+    Bijvoet Difference & su  0.006  0.009  %  (Using   300 reflections. Correl Coef =  90%)
 
  Histogram re-weighted,   226 reflections,  71.0% within interval x= -.5 to 1.5
     Bijvoet Difference & su -0.004  0.013    
@@ -5173,7 +5173,7 @@ Quadrant averages: N, Mean(Do), Mean(Ds) [Summary of scatterplot]
 
 
 @  Flack,1983, Acta Cryst A39, 876-881
-£  Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022
+%  Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022
 $  Hooft et al, 2008, J Appl Cryst, 41, 96-103
 &  Cooper et al, to be published
 

--- a/test_suite/OSXCLI.org/flack.out
+++ b/test_suite/OSXCLI.org/flack.out
@@ -5164,7 +5164,7 @@ Quadrant averages: N, Mean(Do), Mean(Ds) [Summary of scatterplot]
  Using counting statistics weights
        Hooft Parameter & su -0.005  0.012  $ 
            Hole-in-one & su -0.004  0.009    
-    Bijvoet Difference & su  0.006  0.009  £  (Using   300 reflections. Correl Coef =  90%)
+    Bijvoet Difference & su  0.006  0.009  %  (Using   300 reflections. Correl Coef =  90%)
 
  Histogram re-weighted,   226 reflections,  71.0% within interval x= -.5 to 1.5
     Bijvoet Difference & su -0.004  0.013    
@@ -5173,7 +5173,7 @@ Quadrant averages: N, Mean(Do), Mean(Ds) [Summary of scatterplot]
 
 
 @  Flack,1983, Acta Cryst A39, 876-881
-£  Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022
+%  Thompson & Watkin, 2011, J Appl Cryst, 44, 1077-1022
 $  Hooft et al, 2008, J Appl Cryst, 41, 96-103
 &  Cooper et al, to be published
 


### PR DESCRIPTION
Change footnote symbol in CIF to avoid using UK pound sign (not available in some encodings)