### PR TITLE
Fix cameron crash

### DIFF
--- a/cameron/outer.F
+++ b/cameron/outer.F
@@ -139,6 +139,7 @@ C CHECK IF THERE IS A CAMERON.INI
           CALL ZMORE('There is no CAMERON.INI',0)
           CALL ZMORE1('There is no CAMERON.INI',0)
         ENDIF
+        CHRBUF = ' '
         CALL ZCONTR
 c      ELSE
 c        CALL ZSMALL (RCRYST , NSTORE , IDEVIC)


### PR DESCRIPTION
Clear input buffer to avoid use of null string.