### PR TITLE
Fix installer build

### DIFF
--- a/bin/crystals.iss
+++ b/bin/crystals.iss
@@ -75,8 +75,7 @@ Name: {app}\MCE\mce_manual_soubory
 [Files]                                                     
 Source: ..\build\*.*; DestDir: {app}\; Excludes: "make*,buildfile.bat,code.bat"; Flags: ignoreversion;
 Source: ..\build\script\*.*; DestDir: {app}\script\;
-Source: ..\build\mce\*.*; DestDir: {app}\mce\;  Flags: ignoreversion;            
-Source: ..\build\mce\mce_manual_soubory\*.*; DestDir: {app}\mce\mce_manual_soubory\;
+Source: ..\build\mce\*.*; DestDir: {app}\mce\;  Flags: ignoreversion recursesubdirs;            
 Source: ..\build\manual\*.*; DestDir: {app}\manual\;
 Source: ..\build\manual\analyse\*.*; DestDir: {app}\manual\analyse\;
 Source: ..\build\manual\Xray-data\*.*; DestDir: {app}\manual\Xray-data\;

--- a/build/make_w32.bat
+++ b/build/make_w32.bat
@@ -22,8 +22,8 @@ mkdir ..\debuginfo
 mkdir ..\debuginfo\%CRYSVNSAFE%
 copy crystals.pdb ..\debuginfo\%CRYSVNSAFE%\
 copy crystals.exe ..\debuginfo\%CRYSVNSAFE%\
-copy CrashRpt*.dll ..\debuginfo\%CRYSVNSAFE%\
-copy CrashRpt*.pdb ..\debuginfo\%CRYSVNSAFE%\
+@rem copy CrashRpt*.dll ..\debuginfo\%CRYSVNSAFE%\
+@rem copy CrashRpt*.pdb ..\debuginfo\%CRYSVNSAFE%\
 
 @goto exit
 
@@ -51,10 +51,13 @@ copy CrashRpt*.pdb ..\debuginfo\%CRYSVNSAFE%\
 @call make_w32_bits.bat tidy
 @del crystals.pst
 @del cameron.pst
+@del *~
+@del *.bak
+@del CrashSender*.exe
 @mkdir ..\installer
 @cd ..\installer
 @echo Running the setup compiler...
-"%INNOSETUP%"\iscc.exe ../bin/crystals.iss
+"%INNOSETUP%"\iscc.exe ../bin/crystals.iss || ( echo InnoSetup returned an error & exit /b 1 )
 @echo Setup.exe will be in the ..\installer folder if it
 @echo was successful.
 @echo If unsuccessful take out the ECHO OFF statement from the batch file


### PR DESCRIPTION
@richardicooper - the last couple of installer builds on master have failed. Fixed here. This is a consquence of only deploying builds for the master branch (i.e. the installer build is not tested before commiting to master).

This shortcoming is not fixed, but added a quick fail to the script to alert developers when it happens. The failure is also fixed (one of the specified source directories (MCE manual) no longer exists.