### PR TITLE
Slant dialog

### DIFF
--- a/script/xcont.ssc
+++ b/script/xcont.ssc
@@ -57,12 +57,13 @@
 ^^WI {                                                                          
 ^^WI  @ 1,1 GRID TOP NROWS=1 NCOLS=2                                            
 ^^WI  {                                                                         
-^^WI   @ 1,2 GRID GRIDB NROWS=10 NCOLS=3                                        
+^^WI   @ 1,2 GRID GRIDB NROWS=12 NCOLS=3                                        
 ^^WI   {                                                                        
 ^^WI     @ 2,2 BUTTON BOK '&Ok' DEFAULT                                         
 ^^WI     @ 4,2 BUTTON BXX '&Cancel'                                             
 ^^WI     @ 6,2 BUTTON BHELP    '&Help'                                          
 ^^WI     @ 10,2 BUTTON BMOLAX  '&Define plane'                                  
+^^WI     @ 12,2 BUTTON BADD  '&Expand plane (+1.0A)'
 ^^WI   }                                                                        
 ^^WI   @ 1,1 GRID GRIDA NROWS=7 NCOLS=3                                         
 ^^WI   {                                                                        
@@ -169,7 +170,7 @@
 % COPY 'END'                                                                    
 %%                                                                              
 % LOOP                                                                          
-%   VERIFY XC XM XV XN BXX BROWSE BMOLAX BHELP MCEHH  BOK                       
+%   VERIFY XC XM XV XN BXX BROWSE BMOLAX BHELP MCEHH BADD BOK                       
 %   GET NOSTORE SILENT FINAL ABBREVIATED ' ' ' '                                
 %   CASE VALUE                                                                  
 %     BLOCK                       % XC                                          
@@ -226,6 +227,39 @@ view the generated sections.
 %     END BLOCK                                                                 
 %     BLOCK                        % MCE help                                   
 %       COPY '#SPAWN "CRYSDIR:manual/analyse/mce.html"'   
+%     END BLOCK                                                                 
+%%
+%     BLOCK                        % BADD Add 0.5 A to X Y plane
+^^??    _XSTART TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '8.5'                                       
+%       EVALUATE XSTART = VALUE - 0.5
+%       TRANSFER '^^CO SET _XSTART TEXT ' // CHARACTER ( XSTART ) TO DISPLAY
+%%                                                                              
+^^??    _YSTART TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '8.5'                                       
+%       EVALUATE YSTART = VALUE - 0.5
+%       TRANSFER '^^CO SET _YSTART TEXT ' // CHARACTER ( YSTART ) TO DISPLAY
+%%                                                                              
+^^??    _ZSTART TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '8.5'                                         
+%       EVALUATE ZSTART = VALUE - 0.5 
+%       TRANSFER '^^CO SET _ZSTART TEXT ' // CHARACTER ( ZSTART ) TO DISPLAY
+%%                                                                              
+%%                                                                              
+^^??    _XEND TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '8.5'                                       
+%       EVALUATE XEND = VALUE + 0.5
+%       TRANSFER '^^CO SET _XEND TEXT ' // CHARACTER ( XEND ) TO DISPLAY
+%%                                                                              
+^^??    _YEND TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '8.5'                                       
+%       EVALUATE YEND = VALUE + 0.5
+%       TRANSFER '^^CO SET _YEND TEXT ' // CHARACTER ( YEND ) TO DISPLAY
+%%                                                                              
+^^??    _ZEND TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '8.5'                                         
+%       EVALUATE ZEND = VALUE + 0.5                                                 
+%       TRANSFER '^^CO SET _ZEND TEXT ' // CHARACTER ( ZEND ) TO DISPLAY
 %     END BLOCK                                                                 
 %%                                                                              
 %     BLOCK                       % BOK                                         
@@ -323,131 +357,131 @@ view the generated sections.
                                                                                 
 %% SHOW IMAP DOVOID                                                              
                                                                                 
-%      IF IMAP .NE. 0 THEN                                                      
-%       BLOCK                                                                   
-%         ON ERROR TERMINATE                                                    
-%         IF DOSCALE .EQ. 1 .OR. DOCALC .EQ. 1 THEN                             
+%       IF IMAP .NE. 0 THEN                                                      
+%         BLOCK                                                                   
+%           ON ERROR TERMINATE                                                    
+%           IF DOSCALE .EQ. 1 .OR. DOCALC .EQ. 1 THEN                             
 %% Remove any Q atoms, but restore again later.                                 
-%           COPY '#GENERALEDIT 5'                                               
-%           COPY 'GETSERIAL OLDSER'                
-%           COPY 'END'
-%           IF OLDSER .LT. 0 THEN
+%             COPY '#GENERALEDIT 5'                                               
+%             COPY 'GETSERIAL OLDSER'                
+%             COPY 'END'
+%             IF OLDSER .LT. 0 THEN
 %               EVALUATE OLDSER = - OLDSER
-%           END IF
-%           COPY '#EDIT'                                                        
-%           COPY 'SELECT TYPE NE Q'                                             
-%           COPY 'SELECT TYPE NE QH'                                            
-%           COPY 'SELECT TYPE NE QN'                                            
-%           COPY 'END'                                                          
+%             END IF
+%             COPY '#EDIT'                                                        
+%             COPY 'SELECT TYPE NE Q'                                             
+%             COPY 'SELECT TYPE NE QH'                                            
+%             COPY 'SELECT TYPE NE QN'                                            
+%             COPY 'END'                                                          
 %%                                                                              
-%           COPY '#SCRIPT SFLS67'                                               
+%             COPY '#SCRIPT SFLS67'                                               
 %%                                                                              
 %% Restore the list 5 (may have Q atoms in it).                                 
-%           COPY '#DISK'                                                        
-%           CLEAR                                                               
-%           INSERT 'RESET 5 '                                                   
-%           STORE INTEGER OLDSER                                                
-%           SEND                                                                
-%%           COPY '#SUM L 5'                                                     
-%%           COPY 'END'                                                          
-%         END IF                                                                
-%         EVALUATE BORDER = 0.75                                               
+%             COPY '#DISK'                                                        
+%             CLEAR                                                               
+%             INSERT 'RESET 5 '                                                   
+%             STORE INTEGER OLDSER                                                
+%             SEND                                                                
+%%             COPY '#SUM L 5'                                                     
+%%             COPY 'END'                                                          
+%           END IF                                                                
+%           EVALUATE BORDER = 0.75                                               
 %%
-%         EVALUATE XMIN = XSTART                                           
-%         EVALUATE XMAX = XEND
-%         EVALUATE MINX = ( XMIN - BORDER )                                     
-%         EVALUATE STEPX = ( ( XMAX + BORDER ) - MINX ) / RESOL                 
-%         EVALUATE STEPX = 1. + STEPX                                           
+%           EVALUATE XMIN = XSTART                                           
+%           EVALUATE XMAX = XEND
+%           EVALUATE MINX = ( XMIN - BORDER )                                     
+%           EVALUATE STEPX = ( ( XMAX + BORDER ) - MINX ) / RESOL                 
+%           EVALUATE STEPX = 1. + STEPX                                           
 %%
-%         EVALUATE YMIN = YSTART                                          
-%         EVALUATE YMAX = YEND 
-%         EVALUATE MINY = ( YMIN - BORDER )                                     
-%         EVALUATE STEPY = ( ( YMAX + BORDER ) - MINY ) / RESOL                 
-%         EVALUATE STEPY = 1. + STEPY                                           
+%           EVALUATE YMIN = YSTART                                          
+%           EVALUATE YMAX = YEND 
+%           EVALUATE MINY = ( YMIN - BORDER )                                     
+%           EVALUATE STEPY = ( ( YMAX + BORDER ) - MINY ) / RESOL                 
+%           EVALUATE STEPY = 1. + STEPY                                           
 %%
-%         EVALUATE ZMIN = ZSTART                                           
-%         EVALUATE ZMAX = ZEND 
-%         EVALUATE MINZ = ( ZMIN - BORDER )                                     
-%         EVALUATE STEPZ = ( ( ZMAX + BORDER ) - MINZ ) / RESOL                 
-%         EVALUATE STEPZ = 1. + STEPZ                                           
+%           EVALUATE ZMIN = ZSTART                                           
+%           EVALUATE ZMAX = ZEND 
+%           EVALUATE MINZ = ( ZMIN - BORDER )                                     
+%           EVALUATE STEPZ = ( ( ZMAX + BORDER ) - MINZ ) / RESOL                 
+%           EVALUATE STEPZ = 1. + STEPZ                                           
 
-%         EVALUATE IX =  NINT ( STEPX  )
-%         EVALUATE IY =  NINT ( STEPY  )
-%         EVALUATE IZ =  NINT ( STEPZ  )
+%           EVALUATE IX =  NINT ( STEPX  )
+%           EVALUATE IY =  NINT ( STEPY  )
+%           EVALUATE IZ =  NINT ( STEPZ  )
 %% SHOW XSTART YSTART ZSTART
 %% SHOW XEND YEND ZEND
 %% SHOW MINX MINY MINZ 
 %% SHOW STEPX STEPY STEPZ 
 %% SHOW IX IY IZ
-%         QUEUE REWIND                                                          
-%         CLEAR                                                                 
-%         INSERT 'MAP TYPE = '                                                  
-%         CASE IMAP                                                             
-%           INSERT 'F-O'                                                        
-%           INSERT 'DIF'                                                        
-%           INSERT '2FO-FC'                                                     
-%           INSERT 'F-C'                                                        
-%           INSERT 'FO-PAT'                                                     
-%           INSERT 'FC-PAT'                                                     
-%         END CASE                                                              
-%         IF ( IMAP .EQ. 2 ) THEN                                               
-%           INSERT ' MIN-RHO = -1000'                                           
-%         ELSE                                                                  
-%           INSERT ' MIN-RHO = 0'                                               
-%         END IF                                                                
-%         IF RUNVIEWER .EQ. 3 THEN                                              
-%           INSERT ' 10 FILE=MAPVIEW'                                           
-%         ELSE                                                                  
-%           INSERT ' 10 FILE=YES'                                               
-%         END IF                                                                
-%         QUEUE SEND                                                            
-%         CLEAR                                                                 
-%         STORE CHARACTER 'SAVE MOLAX'                                          
-%         QUEUE SEND                                                            
-%         CLEAR                                                                 
-%         INSERT 'DOWN '                                                        
-%         STORE FORMAT /(F7.2)/ LENGTH 7 REAL MINX                              
-%         STORE FORMAT /(I7)/   LENGTH 7 INTEGER IX
-%         STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                             
-%         QUEUE SEND                                                            
-%         CLEAR                                                                 
-%         INSERT 'ACROSS '                                                      
-%         STORE FORMAT /(F7.2)/ LENGTH 7 REAL MINY                              
-%         STORE FORMAT /(I7)/   LENGTH 7 INTEGER IY
-%         STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                             
-%         QUEUE SEND                                                            
-%         CLEAR                                                                 
-%         INSERT 'SECTION '                                                     
-%         STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINZ                              
-%         STORE FORMAT /(I7)/   LENGTH 7 INTEGER IZ
-%         STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                             
-%         QUEUE SEND                                                            
-%       END BLOCK                                                               
+%           QUEUE REWIND                                                          
+%           CLEAR                                                                 
+%           INSERT 'MAP TYPE = '                                                  
+%           CASE IMAP                                                             
+%            INSERT 'F-O'                                                        
+%            INSERT 'DIF'                                                        
+%            INSERT '2FO-FC'                                                     
+%            INSERT 'F-C'                                                        
+%            INSERT 'FO-PAT'                                                     
+%            INSERT 'FC-PAT'                                                     
+%           END CASE                                                              
+%           IF ( IMAP .EQ. 2 ) THEN                                               
+%             INSERT ' MIN-RHO = -1000'                                           
+%           ELSE                                                                  
+%             INSERT ' MIN-RHO = 0'                                               
+%           END IF                                                                
+%           IF RUNVIEWER .EQ. 3 THEN                                              
+%             INSERT ' 10 FILE=MAPVIEW'                                           
+%           ELSE                                                                  
+%             INSERT ' 10 FILE=YES'                                               
+%           END IF                                                                
+%           QUEUE SEND                                                            
+%           CLEAR                                                                 
+%           STORE CHARACTER 'SAVE MOLAX'                                          
+%           QUEUE SEND                                                            
+%           CLEAR                                                                 
+%           INSERT 'DOWN '                                                        
+%           STORE FORMAT /(F7.2)/ LENGTH 7 REAL MINX                              
+%           STORE FORMAT /(I7)/   LENGTH 7 INTEGER IX
+%           STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                             
+%           QUEUE SEND                                                            
+%           CLEAR                                                                 
+%           INSERT 'ACROSS '                                                      
+%           STORE FORMAT /(F7.2)/ LENGTH 7 REAL MINY                              
+%           STORE FORMAT /(I7)/   LENGTH 7 INTEGER IY
+%           STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                             
+%           QUEUE SEND                                                            
+%           CLEAR                                                                 
+%           INSERT 'SECTION '                                                     
+%           STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINZ                              
+%           STORE FORMAT /(I7)/   LENGTH 7 INTEGER IZ
+%           STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                             
+%           QUEUE SEND                                                            
+%         END BLOCK                                                               
 %%                 
-%       IF DOCALC .EQ. 2 THEN     %
+%         IF DOCALC .EQ. 2 THEN     %
 {I  Slant Fourier without calc requires using unmerged L6 data. Map quality may be lower.
 %          COPY '#SLANT 6 '                                                    
 %          QUEUE PROCESS                                                           
 %          COPY 'END'                                                              
 {R * Done. Sub-optimal slant fourier complete.                                              
-%       ELSE 
+%         ELSE 
 %% show f67  (MAPS SHOULD ALWAYS BE DONE ON LIST 7)
-%        IF F67 .EQ. 6 THEN  
+%          IF F67 .EQ. 6 THEN  
 {I ------------------------------------------------                                                    
 {I CRYSTALS should never get here but we will continue
 {I ------------------------------------------------                                                    
 %           COPY '#SLANT 6 '                                                    
-%        ELSE                                                                    
+%          ELSE                                                                    
 %           COPY '#SLANT 7 '                                                    
-%        END IF                                                                  
-%        QUEUE PROCESS                                                           
-%        COPY 'END'                                                              
-%        COPY '#PURGE LIST =7'                                                   
-%        COPY 'END'                                                              
+%          END IF                                                                  
+%          QUEUE PROCESS                                                           
+%          COPY 'END'                                                              
+%          COPY '#PURGE LIST =7'                                                   
+%          COPY 'END'                                                              
 {R * Done. Slant fourier complete.                                              
 %%                                                                              
-%       END IF
-%       IF TWINNED .EQ. TRUE THEN                                               
+%         END IF
+%         IF TWINNED .EQ. TRUE THEN                                               
 %           BLOCK                                                               
 %           ON ERROR TERMINATE                                                  
 %             IF DOSCALE .EQ. 1 THEN                                            
@@ -463,51 +497,51 @@ view the generated sections.
 %               COPY 'END'                                                      
 %             END IF                                                            
 %           END BLOCK                                                           
-%       END IF                                                                  
-%      END IF                                                                   
+%         END IF                                                                  
+%       END IF                                                                   
 %%
-%      IF DOVOID .EQ. 1 THEN                                                    
-%       BLOCK                                                                   
-%        TRANSFER "#STORE CSYS MAP 'void.fou'" TO CRYSTALS                      
-%        QUEUE REWIND                                                           
-%        CLEAR                                                                  
-%        INSERT 'MAP FILE=YES'                                                  
-%        QUEUE SEND                                                             
-%        CLEAR                                                                  
-%        STORE CHARACTER 'SAVE MOLAX'                                           
-%        QUEUE SEND                                                             
-%        CLEAR                                                                  
-%        INSERT 'DOWN '                                                         
-%        STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINX                               
-%        STORE FORMAT /(F7.2)/ LENGTH 7 REAL STEPX                              
-%        STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                              
-%        QUEUE SEND                                                             
-%        CLEAR                                                                  
-%        INSERT 'ACROSS '                                                       
-%        STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINY                               
-%        STORE FORMAT /(F7.2)/ LENGTH 7 REAL STEPY                              
-%        STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                              
-%        QUEUE SEND                                                             
-%        CLEAR                                                                  
-%        INSERT 'SECTION '                                                      
-%        STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINZ                               
-%        STORE FORMAT /(F7.2)/ LENGTH 7 REAL STEPZ                              
-%        STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                              
-%        QUEUE SEND                                                             
-%       END BLOCK                                                               
-%       COPY '#VSLANT'                                                          
-%       QUEUE PROCESS                                                           
-%       COPY 'END'                                                              
+%       IF DOVOID .EQ. 1 THEN                                                    
+%         BLOCK                                                                   
+%          TRANSFER "#STORE CSYS MAP 'void.fou'" TO CRYSTALS                      
+%          QUEUE REWIND                                                           
+%          CLEAR                                                                  
+%          INSERT 'MAP FILE=YES'                                                  
+%          QUEUE SEND                                                             
+%          CLEAR                                                                  
+%          STORE CHARACTER 'SAVE MOLAX'                                           
+%          QUEUE SEND                                                             
+%          CLEAR                                                                  
+%          INSERT 'DOWN '                                                         
+%          STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINX                               
+%          STORE FORMAT /(F7.2)/ LENGTH 7 REAL STEPX                              
+%          STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                              
+%          QUEUE SEND                                                             
+%          CLEAR                                                                  
+%          INSERT 'ACROSS '                                                       
+%          STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINY                               
+%          STORE FORMAT /(F7.2)/ LENGTH 7 REAL STEPY                              
+%          STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                              
+%          QUEUE SEND                                                             
+%          CLEAR                                                                  
+%          INSERT 'SECTION '                                                      
+%          STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINZ                               
+%          STORE FORMAT /(F7.2)/ LENGTH 7 REAL STEPZ                              
+%          STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                              
+%          QUEUE SEND                                                             
+%         END BLOCK                                                               
+%         COPY '#VSLANT'                                                          
+%         QUEUE PROCESS                                                           
+%         COPY 'END'                                                              
 {R * Done. Slant void complete.                                                 
 %%                                                                              
-%      END IF                                                                   
+%       END IF                                                                   
 %%                                                                              
 ^^CO DISPOSE XCONT                                                              
 ^^CO SET PROGOUTPUT TEXT='Slant Fourier complete.'                              
 %%                                                                              
 %% SHOW RUNVIEWER                                                                
 %%                                                                              
-%         CASE RUNVIEWER + 1                                                    
+%       CASE RUNVIEWER + 1                                                    
 %           BLOCK    % Don't run                                                
 %             TRANSFER 'Map file saved as: ' // CFILE TO DISPLAY                
 %           END BLOCK                                                           
@@ -548,9 +582,9 @@ view the generated sections.
 %             TRANSFER '#SPAWN + "WINGXDIR:/for_prog/mapview.exe" Mapfile' -      
               TO CRYSTALS                                                       
 %           END BLOCK                                                           
-%         END CASE                                                              
-%         FINISH                                                                
-%       END BLOCK                                                               
+%       END CASE                                                              
+%       FINISH                                                                
+%     END BLOCK                                                               
 %   END CASE                                                                    
 % END LOOP                                                                      
 %END SCRIPT                                                                     

--- a/script/xcont.ssc
+++ b/script/xcont.ssc
@@ -26,7 +26,7 @@
 %%
 % VARIABLE REAL XMIN XMAX STEPX MINX XSTART XEND
 % VARIABLE REAL YMIN YMAX STEPY MINY YSTART YEND               
-% VARIABLE REAL ZMIN ZMAX STEPZ MINZ ZSTART ZEND
+% VARIABLE REAL ZMIN ZMAX STEPZ MINZ ZSTART ZEND ZMAX
 % VARIABLE INTEGER IX IY IZ
 % VARIABLE REAL ZSECT  RESOL BORDER 
 % VARIABLE CHARACTER CFILE                                                      
@@ -168,7 +168,22 @@
 % COPY 'PLANE'                                                                  
 % COPY 'SAVE'                                                                   
 % COPY 'END'                                                                    
-%%                                                                              
+%%
+%% Make ZSTART and ZEND the same magnitude (max)
+%%
+^^??    _ZSTART TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '1.5'                                         
+%       EVALUATE ZSTART = VALUE 
+^^??    _ZEND TEXT                                                                 
+%       GET NOSTORE SILENT REAL ' ' '1.5'                                         
+%       EVALUATE ZEND = VALUE 
+%       EVALUATE ZMAX = - ZSTART
+%       IF ZMAX .LT. ZEND THEN
+%           EVALUATE ZMAX = ZEND
+%       END IF
+%       TRANSFER '^^CO SET _ZSTART TEXT ' // CHARACTER ( - ZMAX ) TO DISPLAY
+%       TRANSFER '^^CO SET _ZEND TEXT ' // CHARACTER ( ZMAX ) TO DISPLAY
+%%                                                                             
 % LOOP                                                                          
 %   VERIFY XC XM XV XN BXX BROWSE BMOLAX BHELP MCEHH BADD BOK                       
 %   GET NOSTORE SILENT FINAL ABBREVIATED ' ' ' '                                
@@ -399,20 +414,32 @@ view the generated sections.
 %           EVALUATE STEPY = ( ( YMAX + BORDER ) - MINY ) / RESOL                 
 %           EVALUATE STEPY = 1. + STEPY                                           
 %%
+%%
 %           EVALUATE ZMIN = ZSTART                                           
 %           EVALUATE ZMAX = ZEND 
-%           EVALUATE MINZ = ( ZMIN - BORDER )                                     
+%           EVALUATE MINZ = ( ZMIN - BORDER )
 %           EVALUATE STEPZ = ( ( ZMAX + BORDER ) - MINZ ) / RESOL                 
-%           EVALUATE STEPZ = 1. + STEPZ                                           
-
+%           EVALUATE STEPZ = 1. + STEPZ                                     
 %           EVALUATE IX =  NINT ( STEPX  )
 %           EVALUATE IY =  NINT ( STEPY  )
 %           EVALUATE IZ =  NINT ( STEPZ  )
-%% SHOW XSTART YSTART ZSTART
-%% SHOW XEND YEND ZEND
-%% SHOW MINX MINY MINZ 
-%% SHOW STEPX STEPY STEPZ 
-%% SHOW IX IY IZ
+%%
+%% IZ must be an odd number (to centre map on middle plane)
+%%
+%           IF  ( IZ MOD 2 ) .EQ. 0 THEN
+%               EVALUATE IZ = IZ + 1
+%           END IF
+%%
+%% MINZ must be an integer number of resolution steps from zero to centre map on selected atom plane.
+%%
+%           EVALUATE MINZ = - RESOL * REAL ( IZ - 1 ) / 2.0
+%%
+% SHOW XSTART YSTART ZSTART
+% SHOW XEND YEND ZEND
+% SHOW MINX MINY MINZ 
+% SHOW STEPX STEPY STEPZ 
+% SHOW IX IY IZ
+% SHOW RESOL
 %           QUEUE REWIND                                                          
 %           CLEAR                                                                 
 %           INSERT 'MAP TYPE = '                                                  
@@ -452,7 +479,7 @@ view the generated sections.
 %           QUEUE SEND                                                            
 %           CLEAR                                                                 
 %           INSERT 'SECTION '                                                     
-%           STORE FORMAT /(F7.1)/ LENGTH 7 REAL MINZ                              
+%           STORE FORMAT /(F7.2)/ LENGTH 7 REAL MINZ                              
 %           STORE FORMAT /(I7)/   LENGTH 7 INTEGER IZ
 %           STORE FORMAT /(F7.2)/ LENGTH 7 REAL RESOL                             
 %           QUEUE SEND                                                            

--- a/script/xcont.ssc
+++ b/script/xcont.ssc
@@ -424,10 +424,12 @@ view the generated sections.
 %         QUEUE SEND                                                            
 %       END BLOCK                                                               
 %%                 
-%       IF DOCALC .EQ. 2 THEN     %ERROR CONDITION                                                             
-{I  Slant Fourier abandoned
-
-            FINISH
+%       IF DOCALC .EQ. 2 THEN     %
+{I  Slant Fourier without calc requires using unmerged L6 data. Map quality may be lower.
+%          COPY '#SLANT 6 '                                                    
+%          QUEUE PROCESS                                                           
+%          COPY 'END'                                                              
+{R * Done. Sub-optimal slant fourier complete.                                              
 %       ELSE 
 %% show f67  (MAPS SHOULD ALWAYS BE DONE ON LIST 7)
 %        IF F67 .EQ. 6 THEN  
@@ -463,7 +465,7 @@ view the generated sections.
 %           END BLOCK                                                           
 %       END IF                                                                  
 %      END IF                                                                   
-                                                                                
+%%
 %      IF DOVOID .EQ. 1 THEN                                                    
 %       BLOCK                                                                   
 %        TRANSFER "#STORE CSYS MAP 'void.fou'" TO CRYSTALS                      
@@ -500,7 +502,6 @@ view the generated sections.
 %%                                                                              
 %      END IF                                                                   
 %%                                                                              
-                                                                                
 ^^CO DISPOSE XCONT                                                              
 ^^CO SET PROGOUTPUT TEXT='Slant Fourier complete.'                              
 %%                                                                              


### PR DESCRIPTION
@david-watkin - added a button to expand the Slant Fourier volume by 0.5 Angstrom in each direction (useful if looking for features just off the edge of your molecule). 
Also enabled slant map with no recalc of phases - suboptimal, but useful if Fcalc has been imported from an external fcf or similar and you don't want to recalculate it.