### PR TITLE
Add build type variables to installer step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -291,7 +291,9 @@ pipeline {
             }
             environment {
                 CRYSDIR = '.\\,..\\build\\'
-                COMPCODE = 'INW_OMP'
+                COMPCODE = 'INW'
+                CROPENMP = 'TRUE'
+                CR64BIT = 'TRUE'
             }
             steps {
                 bat '''


### PR DESCRIPTION
Installer now has the correct file name (win64-int-openmp)