### PR TITLE
Default to xray sf for non-standard wavelengths

### DIFF
--- a/bits/shelx2cry/shelx_procedures.F90
+++ b/bits/shelx2cry/shelx_procedures.F90
@@ -386,7 +386,7 @@ contains
     list13index = list13index+1
     write (list13(list13index), '(a,F0.5)') 'COND WAVE= ', wavelength
 
-    radiation = 'neutrons'
+    radiation = 'xrays'  !default to X-rays unless NEUT or ELEC keyword found.
 !    write(123,*) 'Lambda = ', wavelength, target, radiation
       wave = nint(100.*wavelength)
 !      write(123,*)' Wave=', wave 


### PR DESCRIPTION
Use NEUT or ELEC (before SFAC) to choose other scattering factor models.

Fixes problem of synchrotron .res files being converted to a model using neutron scattering factors.