### PR TITLE
More icon updates

### DIFF
--- a/gui/cccontroller.cpp
+++ b/gui/cccontroller.cpp
@@ -2950,6 +2950,8 @@ int CcController::GetDescriptor( string &token, int descriptorClass )
                DESCRIPTOR(IconErrorSmall)
                DESCRIPTOR(IconWarnSmall)
                DESCRIPTOR(IconQuerySmall)
+               DESCRIPTOR(IconBlank)
+               DESCRIPTOR(IconBlankSmall)
                DESCRIPTOR(NRes)
                DESCRIPTOR(Style)
                DESCRIPTOR(StyleSmooth)
@@ -2990,6 +2992,7 @@ int CcController::GetDescriptor( string &token, int descriptorClass )
                DESCRIPTOR(ShowGroups)
                DESCRIPTOR(Value)
                DESCRIPTOR(ToolTip)
+               DESCRIPTOR(SetIcon)
              break;
 
       case kChartClass:

--- a/gui/cricon.cpp
+++ b/gui/cricon.cpp
@@ -93,6 +93,14 @@ CcParse     CrIcon::ParseInput( deque<string> & tokenList )
 				LOGSTAT( "CrIcon:ParseInput Setting Tooltip Text ");
 				break;
 			}
+			case kTSetIcon:
+			{
+				tokenList.pop_front(); // Remove that token!
+				((CxIcon *)ptr_to_cxObject)->SetIconType( CcController::GetDescriptor( tokenList.front(), kAttributeClass ) );
+				tokenList.pop_front();
+				LOGSTAT( "CrIcon:ParseInput Changing icon ");
+				break;
+			}
 			default:
 			{
 				hasTokenForMe = false;

--- a/gui/cricon.h
+++ b/gui/cricon.h
@@ -42,6 +42,7 @@ class CrIcon : public CrGUIElement
 
 };
 
+#define     kSSetIcon          "SETICON"
 #define     kSIconInfo          "INFO"
 #define     kSIconError         "ERROR"
 #define     kSIconWarn          "WARN"
@@ -50,6 +51,9 @@ class CrIcon : public CrGUIElement
 #define     kSIconErrorSmall         "SMALLERROR"
 #define     kSIconWarnSmall          "SMALLWARN"
 #define     kSIconQuerySmall         "SMALLQUERY"
+#define     kSIconBlank         "BLANK"
+#define     kSIconBlankSmall          "SMALLBLANK"
+
 
 enum
 {
@@ -60,7 +64,10 @@ enum
  kTIconInfoSmall,
  kTIconErrorSmall,
  kTIconWarnSmall,
- kTIconQuerySmall
+ kTIconQuerySmall, 
+ kTSetIcon,
+ kTIconBlank, 
+ kTIconBlankSmall
 };
 
 #endif

--- a/gui/cxicon.h
+++ b/gui/cxicon.h
@@ -41,6 +41,7 @@
 
 class CrIcon;
 class CxGrid;
+class CxTab;
 
 class CxIcon : public BASETEXT
 {
@@ -62,7 +63,8 @@ class CxIcon : public BASETEXT
 
         // attributes
         CrGUIElement *  ptr_to_crObject;
-
+		CxTab* notebookParent;
+		
     protected:
         // attributes
 		wxBitmap mbitmap;


### PR DESCRIPTION
Added ability to change icon on the fly using SETICON (size does not change - so use same size icons). Could be used to add warning icons to outlying metrics (R, goof, etc).
Added BLANK icons to occupy space when no other icon is shown (see use case above)
Fix background of icons when they are in a  tab control on Windows (white instead of grey).