### PR TITLE
Use heap for passing large array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,8 +408,8 @@ ELSEIF ( IFORT_COMPILER ) # ifort (untested)
 
   ELSE()
 
-	    SET (CMAKE_Fortran_FLAGS_RELEASE "-O3 -fpp -MD -Qdiag-disable:8291 -traceback -QaxSSE2")
-	    SET (CMAKE_Fortran_FLAGS_DEBUG   "-check:all -MDd -debug:all -Qtrapuv -fpe0 -fpp -warn:nofileopt -Qdiag-disable:8291 -Qdiag-disable:8290 -check:format -check:overflow -check:pointers -check:noarg_temp_created -check:uninit -traceback -check:nooutput_conversion")
+	    SET (CMAKE_Fortran_FLAGS_RELEASE "-O3 -fpp -MD /heap-arrays:8 -Qdiag-disable:8291 -traceback -QaxSSE2")
+	    SET (CMAKE_Fortran_FLAGS_DEBUG   "-check:all -MDd /heap-arrays:8 -debug:all -Qtrapuv -fpe0 -fpp -warn:nofileopt -Qdiag-disable:8291 -Qdiag-disable:8290 -check:format -check:overflow -check:pointers -check:noarg_temp_created -check:uninit -traceback -check:nooutput_conversion")
 
     	SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}  /O2  /EHs /W3 /Oy- ")
     	SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /EHs /W3 /Oy- ")


### PR DESCRIPTION
Option was enabled as a fix for stack overflow on old batch based ifort builds. Added to the cmake ifort builds.