### PR TITLE
Fix bond calc for atoms starting with L, M or R.

### DIFF
--- a/crystals/distangl.F
+++ b/crystals/distangl.F
@@ -7107,10 +7107,10 @@ C Read the properties file and extract cov, vdw and colour.
             END IF
             NOTFND = NOTFND + 1
             WRITE(CATTYP,'(A4)')ISTORE(M5)
-            IF (( CATTYP(1:1).NE.'Q' ) .AND.
-     1          ( CATTYP(1:1).NE.'L' ) .AND.
-     1          ( CATTYP(1:1).NE.'M' ) .AND.
-     1          ( CATTYP(1:1).NE.'R' )) THEN
+            IF (( CATTYP(1:2).NE.'Q ' ) .AND.
+     1          ( CATTYP(1:2).NE.'L ' ) .AND.
+     1          ( CATTYP(1:2).NE.'M ' ) .AND.
+     1          ( CATTYP(1:2).NE.'R ' )) THEN
               WRITE(CMON,'(3A)')
      1 'FYI: Element not in L40 or L29: ',ISTORE(M5),ICOL
               CALL XPRVDU(NCVDU,1,0)
@@ -7164,9 +7164,9 @@ C -- elements which will override the TOLERANCE calculation.
       DO I5 = 0,N5-1
          M5 = L5 + I5*MD5
          WRITE(CATTYP,'(A4)')ISTORE(M5)
-         IF (( CATTYP(1:1).EQ.'L' ) .OR.
-     1       ( CATTYP(1:1).EQ.'M' ) .OR.
-     2       ( CATTYP(1:1).EQ.'R' )) CYCLE
+         IF (( CATTYP(1:2).EQ.'L ' ) .OR.
+     1       ( CATTYP(1:2).EQ.'M ' ) .OR.
+     2       ( CATTYP(1:2).EQ.'R ' )) CYCLE
 
          NEXTLC = NFL
          NFOUND = MAKE41( M5, NEXTLC )


### PR DESCRIPTION
Revert bug from March where L, M, R are ignored in bonding calc (but also accidentally ignored bonds from Li, Mg, Mn, Ru, Re, etc). Effect was sometimes missed because reverse direction bonds were allowed, so effect depended on atom order).