### PR TITLE
Change XPCH5E to XPCH9E because it deals with LIST 9

### DIFF
--- a/crystals/input.F
+++ b/crystals/input.F
@@ -47,7 +47,7 @@ C block (l5,l9,l10) addresses itself.
 C XFAL09 loads a LIST 9, and saves the LIST 5 addresses if L5 is already in core.
 C
 C Revision 1.19  2011/02/04 17:40:01  djw
-C XPCH5E either prints table of esds or creates a LIST 9. Operations need to be separated in the near future
+C XPCH9E either prints table of esds or creates a LIST 9. Operations need to be separated in the near future
 C
 C Revision 1.18  2010/07/21 15:55:16  djw
 C Comment out diagnostics
@@ -310,7 +310,7 @@ C----- CREATE ESD LIST
       NR61=ITEMP2
       CALL XRSL
       CALL XCSAE
-      CALL XPCH5E(2)
+      CALL XPCH9E(2)
       RETURN
 
 C--LIST PRINT ROUTINE
@@ -390,7 +390,7 @@ c             just the symbol
             call XPCH4
             return
       else if(lstno.eq.9) then   !check for LIST 9 !DISGUISED AS A LIST 5
-            call XPCH5E(2)
+            call XPCH9E(3)
             return
       else if(lstno.eq.13) then   !check for LIST 13
             call XPCH13
@@ -456,7 +456,7 @@ C-- 5D 'CHIME' XYZ FORMAT
       RETURN
 C-- 5E ESDS IN SIMPLE FORMAT
 7350  CONTINUE
-      CALL XPCH5E(1)
+      CALL XPCH9E(1)
       RETURN
 c-- CRYSTALS format without header or overall
 7360  CONTINUE

--- a/crystals/lists4.F
+++ b/crystals/lists4.F
@@ -21,7 +21,7 @@ C Revision 1.27  2011/02/07 17:01:15  djw
 C Use #PUNCH 5 E as a stop-gap mechanism for creating a LIST 9 with paramter esds. The matrix of constraint is applied
 C
 C Revision 1.26  2011/02/04 17:40:01  djw
-C XPCH5E either prints table of esds or creates a LIST 9. Operations need to be separated in the near future
+C XPCH9E either prints table of esds or creates a LIST 9. Operations need to be separated in the near future
 C
 C Revision 1.25  2010/09/20 14:59:51  djw
 C Enable storage of an auxilliary radiation at the end of each scattering factor record in LIST 3

--- a/crystals/punch.F
+++ b/crystals/punch.F
@@ -87,7 +87,7 @@ C block (l5,l9,l10) addresses itself.
 C XFAL09 loads a LIST 9, and saves the LIST 5 addresses if L5 is already in core.
 C
 C Revision 1.56  2011/02/04 17:40:01  djw
-C XPCH5E either prints table of esds or creates a LIST 9. Operations need to be separated in the near future
+C XPCH9E either prints table of esds or creates a LIST 9. Operations need to be separated in the near future
 C
 C Revision 1.55  2010/07/21 15:57:54  djw
 C Change order of list 6 header lines
@@ -706,13 +706,13 @@ C Close the .PDB FILE
       RETURN
       END
 C
-CODE FOR XPCH5E
-      SUBROUTINE XPCH5E(ITYPE)
+CODE FOR XPCH9E
+      SUBROUTINE XPCH9E(ITYPE)
 C--PRINT LIST 5 WITH ESDS/CREATE LIST 9
 c
 c      ITYPE 1 FOR PRINTED LIST
 C      ITYPE 2 FOR CREATION OF LIST 9
-C
+C      ITYPE 3 TO OUTPUT A LIST 9
 c      This is really horrid code (DJW, Feb2011)
 c      A LIST 5 and LIST 12 is loaded
 c      The short records are over written with esds from LIST 12
@@ -831,8 +831,10 @@ c--         move the type and serial
             call xmove(store(m5),store(m9a),2)
 c--         move the esds
             call xmove(bpd(1),store(m9a+2),11)
-c-2021            write(ncpu,20)store(m9a),nint(store(m9a+1)),
-c-2021     1      (store(idjw),idjw=m9a+2, m9a+12)
+            if (itype.eq.3) then !Punch list
+             write(ncpu,20)store(m9a),nint(store(m9a+1)),
+     1       (store(idjw),idjw=m9a+2, m9a+12)
+            endif
         ENDIF
 C
 1585    CONTINUE

--- a/crystals/results.F
+++ b/crystals/results.F
@@ -1378,7 +1378,7 @@ C--INPUT WENT OKAY  -  CLEAR THE CORE AGAIN
       CALL XRSL
       CALL XCSAE
       IF ( IPESD .NE. 0 ) THEN     !FORM THE ABSOLUTE LIST 12
-       CALL XPCH5E(2)   ! ENSURE A LIST 9 (ESDS) EXISTS IF THE MATRIX IS OK
+       CALL XPCH9E(2)   ! ENSURE A LIST 9 (ESDS) EXISTS IF THE MATRIX IS OK
        CALL XRSL
        CALL XCSAE
        IF (KHUNTR(09,0,IADDL,IADDR,IADDD,-1).NE.0) CALL XFAL09
@@ -2667,7 +2667,7 @@ C
       IFUNC = IFUNC
       CALL XRSL
       CALL XCSAE
-c  LIST 5 should already be loaded by XPCH5E
+c  LIST 5 should already be loaded by XPCH9E
       IF (KHUNTR(05,0,IADDL,IADDR,IADDD,-1).NE.0) CALL XFAL05 
       IF ( MD5ES .EQ. 0 ) RETURN
 
@@ -2675,7 +2675,7 @@ CDJWMAY99 - PREAPRE TO APPEND CIF OUTPUT ON FRN1
       CALL XMOVEI(KEYFIL(1,23), KDEV, 4)
       CALL XRDOPN(8, KDEV , CSSCIF, LSSCIF)
 C
-c  LIST 1, 5 and 9 should have been loaded in XPCH5E
+c  LIST 1, 5 and 9 should have been loaded in XPCH9E
       IF (KHUNTR(01,0,IADDL,IADDR,IADDD,-1).NE.0) CALL XFAL01
       IF (KHUNTR(13,0,IADDL,IADDR,IADDD,-1).NE.0) CALL XFAL13
       if (ipesd.ne.0) then
@@ -4878,7 +4878,7 @@ CRICJUN02 - Last minute SFLS calc to get threshold cutoffs into 30.
 C----- SET REFLECTION LISTING TYPE (LIST 6)
 c-Nov-19         ITYP06 = 1              !Remove call to sfls because of problems
 c         CALL XSFLSB(-1,ITYP06)         !re-using LIST 33 if previous task involved LIST 7
-C-JAN-19         CALL XPCH5E(2)          !CREATE A LIST 9 (ESDS)
+C-JAN-19         CALL XPCH9E(2)          !CREATE A LIST 9 (ESDS)
       ENDIF
 CRICJUN02 - Last minute SFLS calc to get threshold cutoffs into 30.
 

--- a/script/xhtml.ssc
+++ b/script/xhtml.ssc
@@ -17,6 +17,7 @@
 %    COPY 'E.S.D YES'
 %    COPY 'OUTPUT MON=DIST PUNCH = HTML HESD=NONFIXED'
 %    COPY 'END'
+%    COPY '#RELEASE PUNCH logs/bfile.pch'
 %%
 %%
 %    EVALUATE QTITLE = 'HTML report'


### PR DESCRIPTION
Change INPUT, PUNCH, RESULTS to refer to XPCH9E rather than 5E.  Add extra possible argument value on CALL .  1&2 as before, 3 causes LIST 9 to be cleanly output to BFILE.PCH.
Make xhtml.ssc switch punch output back to bfile.pch after html output is finished.