### PR TITLE
Avoid re-import of hkl data when solving structures in SHELXT

### DIFF
--- a/script/xshelxt.ssc
+++ b/script/xshelxt.ssc
@@ -199,7 +199,7 @@
 %     IF FILEEXISTS ( 'shelxt_input.cry' ) THEN
 %       EVALUATE T =  FILEDELETE ( 'shelxt_input.cry' )
 %     END IF
-% TRANSFER '#SPAWN % "CRYSDIR:shelx2cry.exe" -o shelxt_input.cry shelxt_a.res' -
+% TRANSFER '#SPAWN % "CRYSDIR:shelx2cry.exe" -n -o shelxt_input.cry shelxt_a.res' -
  TO CRYSTALS
 %%
 %     IF FILEEXISTS ( 'shelxt_input.cry' ) THEN


### PR DESCRIPTION
(DJW fixes) Previous default reimported merged data resulting in loss of useful statistics. xshelxt.scp now uses '-n' flag for shelx2cry.exe
If '-n' is specified, shelx2cry.exe does not put hkl importing code into output.