### PR TITLE
Fix ifort cache

### DIFF
--- a/.github/workflows/CI-intel.yml
+++ b/.github/workflows/CI-intel.yml
@@ -84,7 +84,7 @@ jobs:
       id: cache-install-oneapi
       uses: actions/cache@v4
       with:
-        path: C:\Program Files (x86)\Intel\oneAPI
+        path: "C:\Program Files (x86)\Intel\oneAPI"
         key: install-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_MKL_COMPONENTS }}-mkl-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-${{ hashFiles('**/bin/cache_exclude_windows.sh') }}
 
     - name: install oneapi

--- a/.github/workflows/CI-intel.yml
+++ b/.github/workflows/CI-intel.yml
@@ -84,7 +84,7 @@ jobs:
       id: cache-install-oneapi
       uses: actions/cache@v4
       with:
-        path: "C:\Program Files (x86)\Intel\oneAPI"
+        path: 'C:\Program Files (x86)\Intel\oneAPI'
         key: install-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_MKL_COMPONENTS }}-mkl-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_FORTRAN_COMPONENTS }}-${{ hashFiles('**/bin/cache_exclude_windows.sh') }}
 
     - name: install oneapi


### PR DESCRIPTION
Caching of Intel fotran compiler install was failing due to a space in the path to the compiler. Fixed by adding single quotes.